### PR TITLE
added theme-color tags to some timing and run pages

### DIFF
--- a/application/views/runs/metro.pug
+++ b/application/views/runs/metro.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  
+  meta(property='theme-color' content="#0072CE")
+
 block title
   span=title
   

--- a/application/views/runs/vline.pug
+++ b/application/views/runs/vline.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  
+  meta(property='theme-color' content="#8F1A95")
+
 block title
   span=title
   

--- a/application/views/timings/ferry.pug
+++ b/application/views/timings/ferry.pug
@@ -7,7 +7,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
-    
+  meta(property='theme-color' content="#00A499")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/metro-trains.pug
+++ b/application/views/timings/metro-trains.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 90 minutes of metropolitain train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 90 minutes of departures from ${stationName}`)
-    
+  meta(property='theme-color' content="#0072CE")
+  
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/regional-coach.pug
+++ b/application/views/timings/regional-coach.pug
@@ -7,7 +7,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
-    
+  meta(property='theme-color' content="#A57FB2")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/vline.pug
+++ b/application/views/timings/vline.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
-    
+  meta(property='theme-color' content="#8F1A95")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')


### PR DESCRIPTION
Add theme colours for mobile browsers to match the specific colour assigned in the PTV Style Guide

Done:

- [x] Metro Trains - timings
- [x] Metro Trains - runs
- [x]  V/Line (coach) - timings
- [x] Ferry - timings
- [x] V/Line (rail) - timings
- [x] V/Line (rail) - runs
- [x] Ferry - runs
- [x] Trams - timings
- [x] Trams - runs
- [x] Buses - runs
- [x] Buses - timings
- [x]  V/Line (coach) - runs