### PR TITLE
added theme-color tags to some timing and run pages

### DIFF
--- a/application/views/layout.pug
+++ b/application/views/layout.pug
@@ -1,6 +1,7 @@
 doctype html
 html(lang='en-GB')
   head
+    - let themeColour = '#171717'
     meta(charset='UTF-8')
       
     link(rel='preload' href='/static/fonts/Nunito.ttf' as='font' crossorigin='anonymous')
@@ -23,7 +24,6 @@ html(lang='en-GB')
     meta(name='application-name' content='TransportVic')
     meta(name='viewport' content='initial-scale=1.0, maximum-scale=1.0, user-scalable=no, width=device-width, height=device-height')
     meta(name='google' content='notranslate')
-    meta(name='theme-color' content='#171717')
     meta(name='apple-mobile-web-app-capable' content='yes')
     meta(name='mobile-web-app-capable' content='yes')
     meta(name='apple-mobile-web-app-status-bar-style' content='black-translucent')
@@ -34,6 +34,7 @@ html(lang='en-GB')
       
     link(rel='manifest' href='/static/app-content/manifest.json')
     block head
+    meta(name='theme-color' content=themeColour)
   body
     div#header
       block title

--- a/application/views/runs/generic.pug
+++ b/application/views/runs/generic.pug
@@ -13,7 +13,23 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  
+  -
+    switch (trip.mode) {
+      case 'bus':
+        themeColour = '#d7832c'
+        break
+      case 'tram':
+        themeColour = '#20b734'
+        break
+      case 'regional coach':
+        themeColour = '#9582b5'
+        break
+      case 'ferry':
+        themeColour = '#03998f'
+        break
+    }
+    
+    
 block title
   span=title
   

--- a/application/views/runs/metro.pug
+++ b/application/views/runs/metro.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  
+  meta(property='theme-color' content="#0072CE")
+
 block title
   span=title
   

--- a/application/views/runs/metro.pug
+++ b/application/views/runs/metro.pug
@@ -8,7 +8,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  meta(property='theme-color' content="#0072CE")
+  - themeColour = '#0570c3'
 
 block title
   span=title

--- a/application/views/runs/vline.pug
+++ b/application/views/runs/vline.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  
+  meta(property='theme-color' content="#8F1A95")
+
 block title
   span=title
   

--- a/application/views/runs/vline.pug
+++ b/application/views/runs/vline.pug
@@ -8,7 +8,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${title}`)
   meta(property='og:description' content=`Viewing the ${title}`)
   meta(property='twitter:description' content=`Viewing the ${title}`)
-  meta(property='theme-color' content="#8F1A95")
+  - themeColour = '#6b4d9e'
 
 block title
   span=title

--- a/application/views/timings/ferry.pug
+++ b/application/views/timings/ferry.pug
@@ -7,7 +7,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
-    
+  meta(property='theme-color' content="#00A499")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/ferry.pug
+++ b/application/views/timings/ferry.pug
@@ -7,7 +7,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 ferry departures from ${stop.stopName}`)
-  meta(property='theme-color' content="#00A499")
+  - themeColour = '#03998f'
 
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')

--- a/application/views/timings/grouped.pug
+++ b/application/views/timings/grouped.pug
@@ -7,6 +7,15 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 ${currentMode} departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 ${currentMode} departures from ${stop.stopName}`)
+  -
+    switch (currentMode) {
+      case 'bus':
+        themeColour = '#d7832c'
+        break
+      case 'tram':
+        themeColour = '#20b734'
+        break
+    }
     
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')

--- a/application/views/timings/metro-trains.pug
+++ b/application/views/timings/metro-trains.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 90 minutes of metropolitain train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 90 minutes of departures from ${stationName}`)
-    
+  meta(property='theme-color' content="#0072CE")
+  
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/metro-trains.pug
+++ b/application/views/timings/metro-trains.pug
@@ -8,7 +8,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 90 minutes of metropolitain train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 90 minutes of departures from ${stationName}`)
-  meta(property='theme-color' content="#0072CE")
+  - themeColour = '#0570c3'
   
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')

--- a/application/views/timings/regional-coach.pug
+++ b/application/views/timings/regional-coach.pug
@@ -7,7 +7,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
-  meta(property='theme-color' content="#A57FB2")
+  - themeColour = '#9582b5'
 
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')

--- a/application/views/timings/regional-coach.pug
+++ b/application/views/timings/regional-coach.pug
@@ -7,7 +7,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stop.stopName}`)
   meta(property='og:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
   meta(property='twitter:description' content=`Viewing the Next 4 coach departures from ${stop.stopName}`)
-    
+  meta(property='theme-color' content="#A57FB2")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')

--- a/application/views/timings/vline.pug
+++ b/application/views/timings/vline.pug
@@ -8,7 +8,7 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
-  meta(property='theme-color' content="#8F1A95")
+  - themeColour = '#6b4d9e'
 
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')

--- a/application/views/timings/vline.pug
+++ b/application/views/timings/vline.pug
@@ -8,7 +8,8 @@ block head
   meta(property='twitter:title' content=`TransportVic - ${stationName}`)
   meta(property='og:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
   meta(property='twitter:description' content=`Viewing the Next 3 hours of V/Line train departures from ${stationName}`)
-    
+  meta(property='theme-color' content="#8F1A95")
+
   link(rel='preload' as='image' href='/static/images/clear-icons/bus.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/coach.svg')
   link(rel='preload' as='image' href='/static/images/clear-icons/tram.svg')


### PR DESCRIPTION
Add theme colours for mobile browsers to match the specific colour assigned in the PTV Style Guide

Done:

- [x] Metro Trains - timings
- [x] Metro Trains - runs
- [x]  V/Line (coach) - timings
- [x] Ferry - timings
- [x] V/Line (rail) - timings
- [x] V/Line (rail) - runs

TO DO:
- [ ] Ferry - runs
- [ ] Trams - timings
- [ ] Trams - runs
- [ ]  V/Line (coach) - runs