### PR TITLE
Added options to change colours, along with hide the actual departure time 

### DIFF
--- a/application/routes/mockups/Metro-CRT-PIDS.mjs
+++ b/application/routes/mockups/Metro-CRT-PIDS.mjs
@@ -13,7 +13,7 @@ async function getData(req, res) {
 router.get('/:station/:platform', async (req, res) => {
   getData(req, res)
 
-  res.render('mockups/metro-crt', { now: utils.now() })
+  res.render('mockups/metro-crt', { now: utils.now(), query: req.query })
 })
 
 router.post('/:station/:platform/', async (req, res) => {

--- a/application/static/css/mockups/metro-crt.css
+++ b/application/static/css/mockups/metro-crt.css
@@ -6,7 +6,7 @@ body {
   align-items: center;
   background-color: #000000;
   color: #ffffff;
-  font-family: "Helvetica";
+  font-family: "Arial";
   font-weight: 800;
 }
 

--- a/application/static/css/mockups/metro-crt.css
+++ b/application/static/css/mockups/metro-crt.css
@@ -6,7 +6,7 @@ body {
   align-items: center;
   background-color: #000000;
   color: #ffffff;
-  font-family: "Arial";
+  font-family: "Helvetica";
   font-weight: 800;
 }
 

--- a/application/views/mockups/metro-crt.pug
+++ b/application/views/mockups/metro-crt.pug
@@ -7,7 +7,12 @@ html
     link(rel='stylesheet' href=`${staticBase}/static/css/mockups/metro-crt.css`)
     
     link(rel='preload' as='style' href=`${staticBase}/static/css/mockups/base-style.css`)
-  body
+    - let bodyStyle = ''
+    - if (query.background) bodyStyle += `background-color: ${query.background};`
+    - if (query.color) bodyStyle += ` color: ${query.color};`
+    - let departStyle = ''
+    - if (query.hideDepart) departStyle += `display: none;`
+    body(style=bodyStyle)
     div.crt.leftCRT
       div.destination
         span --
@@ -15,7 +20,7 @@ html
         div.scheduled
           span SCHEDULED
           span.scheduledDepartureTime --
-        div.actual
+        div.actual(style=departStyle)
           span DEPARTING
           span.departingMinutes -- 
           span.min MIN


### PR DESCRIPTION
Love the site but noticed the CRT view font wasn't quite right I think Arial is a lot closer to the font used.  (Screenshot attached) 

http://localhost:8000/mockups/metro-crt/box-hill/2?background=blue

**Updated** 

<img width="1965" height="778" alt="Screenshot from 2025-12-21 17-18-26" src="https://github.com/user-attachments/assets/44188bcb-dd5b-426d-b8c6-b9547ba73c1f" />

**Reference** 
<img width="3144" height="1764" alt="Screenshot from 2025-12-21 11-06-46" src="https://github.com/user-attachments/assets/5efc19cd-b104-4049-b1a4-c2d773311b2e" />

I also added query args to set the background and font colours so you can get the blue and white look  or the green and black look seen here example url http://localhost:8000/mockups/metro-crt/box-hill/2?color=green

**Updated**
<img width="1965" height="778" alt="image" src="https://github.com/user-attachments/assets/80e8fca0-e5ba-466b-8b45-cc9686f5438c" />

**Reference** 
![167_6781_595](https://github.com/user-attachments/assets/05274468-4c1f-4146-a2ef-708301b8bd5d)


You can also hide the depart time (No idea why you would but the old reference photos had it so thought I would chuck it in) 

http://localhost:8000/mockups/metro-crt/box-hill/2?color=green&hideDepart=1

<img width="1192" height="466" alt="Screenshot from 2025-12-21 17-24-57" src="https://github.com/user-attachments/assets/6a4a851a-037f-46d0-8369-1f4eb40eb9dd" />

Note I was unable to get the times working locally the other screenshots I updated the css on the site but have tested they at least load and update the css without the times locally.

npm run test is passing
